### PR TITLE
V5.0: Added format to fix range intervals where only first interval has an era

### DIFF
--- a/services/structureddate/structureddate/src/main/antlr4/org/collectionspace/services/structureddate/antlr/StructuredDate.g4
+++ b/services/structureddate/structureddate/src/main/antlr4/org/collectionspace/services/structureddate/antlr/StructuredDate.g4
@@ -20,7 +20,8 @@ displayDate:           uncertainDate
 
 uncertainDate:         CIRCA certainDate ;
 
-certainDate:           hyphenatedRange
+certainDate:           partialEraRange
+|                      hyphenatedRange
 |                      singleInterval
 ;
 
@@ -96,6 +97,7 @@ century:               ( strCentury | numCentury ) era? ;
 
 millennium:            nth MILLENNIUM era? ;
 
+partialEraRange:      num strMonth num era (DASH|HYPHEN) num strMonth num ;
 romanDate:             num (HYPHEN | SLASH) romanMonth (HYPHEN | SLASH) numYear era? ;
 strDate:               strMonth ( numDayOfMonth | nth ) COMMA? numYear era?;
 invStrDate:            era num COMMA? strMonth num

--- a/services/structureddate/structureddate/src/main/java/org/collectionspace/services/structureddate/antlr/ANTLRStructuredDateEvaluator.java
+++ b/services/structureddate/structureddate/src/main/java/org/collectionspace/services/structureddate/antlr/ANTLRStructuredDateEvaluator.java
@@ -76,6 +76,7 @@ import org.collectionspace.services.structureddate.antlr.StructuredDateParser.Nu
 import org.collectionspace.services.structureddate.antlr.StructuredDateParser.PartOfContext;
 import org.collectionspace.services.structureddate.antlr.StructuredDateParser.PartialCenturyContext;
 import org.collectionspace.services.structureddate.antlr.StructuredDateParser.PartialDecadeContext;
+import org.collectionspace.services.structureddate.antlr.StructuredDateParser.PartialEraRangeContext;
 import org.collectionspace.services.structureddate.antlr.StructuredDateParser.PartialYearContext;
 import org.collectionspace.services.structureddate.antlr.StructuredDateParser.RomanDateContext;
 import org.collectionspace.services.structureddate.antlr.StructuredDateParser.QuarterCenturyContext;
@@ -1198,6 +1199,23 @@ public class ANTLRStructuredDateEvaluator extends StructuredDateBaseListener imp
 	}
 
 	@Override
+	public void exitPartialEraRange(PartialEraRangeContext ctx) {
+		if (ctx.exception != null) return;
+
+		Integer secondYear = (Integer) stack.pop();
+		Integer secondMonth = (Integer) stack.pop();
+		Integer secondDay = (Integer) stack.pop();
+
+		Era era = (Era) stack.pop();
+		Integer firstYear = (Integer) stack.pop();
+		Integer firstMonth = (Integer) stack.pop();
+		Integer firstDay = (Integer) stack.pop();
+
+		stack.push(new Date(secondYear, secondMonth, secondDay, null));
+		stack.push(new Date(firstYear, firstMonth, firstDay, era));
+	}
+
+	@Override
 	public void exitNum(NumContext ctx) {
 		if (ctx.exception != null) return;
 
@@ -1219,7 +1237,6 @@ public class ANTLRStructuredDateEvaluator extends StructuredDateBaseListener imp
 	@Override
 	public void exitRomanDate(RomanDateContext ctx) {
 		if (ctx.exception != null) return;
-		System.out.println("I am going in here");
 		
 		Era era = (ctx.era() == null) ? null : (Era) stack.pop();
 		Integer year = (Integer) stack.pop();

--- a/services/structureddate/structureddate/src/test/resources/test-dates.yaml
+++ b/services/structureddate/structureddate/src/test/resources/test-dates.yaml
@@ -1266,12 +1266,16 @@
   '29-IV-2018':                          # Day-Month-Year with roman numeral as month 
                                          earliestSingleDate: [2018,  4,  29, CE]
 
-  '01-IV-2017 BCE':                          # Day-Month-Year with roman numeral as month, with Era
-                                          earliestSingleDate: [2017, 4, 1, BCE]  
+  '01-IV-2017 BCE':                      # Day-Month-Year with roman numeral as month, with Era
+                                         earliestSingleDate: [2017, 4, 1, BCE]  
   
-  # '12 june 1942 - 13 june 1943':            # hyphenatedRange, date with comma'd numbers
-  #                                        earliestSingleDate: [1942,  6,  12, CE]
-  #                                        latestDate:         [1942,  6,  13, CE]
+  '12 june 1942 BCE - 13 june 1943':     # hyphenatedRange range with era only in first interval, mixed eras
+                                         earliestSingleDate: [1942,  6,  12, BCE]
+                                         latestDate:         [1943,  6,  13, CE]
+
+  '13 april 1995 CE - 18 april 2019':    # hyphenatedRange range with era only in first interval
+                                         earliestSingleDate: [1995, 4, 13, CE]
+                                         latestDate:         [2019, 4, 18, CE]
 
 # -------------------------------------------------------------------------------------------------------
 # Invalid dates


### PR DESCRIPTION
Example:
12 june 1995 BCE - 1 jan 01 (CE is implied in this format)